### PR TITLE
Fix typo in comment filter option

### DIFF
--- a/lib/ansible/plugins/filter/comment.yml
+++ b/lib/ansible/plugins/filter/comment.yml
@@ -38,7 +38,7 @@ DOCUMENTATION:
     postfix:
       description: Indicator of the end of each line inside a comment block, only available for styles that support multiline comments.
       type: string
-    protfix_count:
+    postfix_count:
       description: Number of times to add a postfix at the end of a line, when a prefix exists and is usable.
       type: int
       default: 1


### PR DESCRIPTION
##### SUMMARY

Fixes a typo in one of the options.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`comment` filter

##### ADDITIONAL INFORMATION

Before:
```
protfix_count:
  description: Number of times to add a postfix at the end of a line, when a prefix exists and is usable.
  type: int
  default: 1
```

After:
```
postfix_count:
  description: Number of times to add a postfix at the end of a line, when a prefix exists and is usable.
  type: int
  default: 1
```
